### PR TITLE
Added awakeFromNib to support Interface Builder

### DIFF
--- a/RealTimeBlur/Classes/DRNRealTimeBlurView.m
+++ b/RealTimeBlur/Classes/DRNRealTimeBlurView.m
@@ -94,7 +94,6 @@
     [[DRNRealTimeBlurViewManager sharedManager] deregisterView:self];
 }
 
-
 #pragma mark - Properties
 
 /* When renderStatic is YES, the view is not rendered every kDRNRealTimeBlurViewRenderPeriod seconds.

--- a/RealTimeBlur/Classes/DRNRealTimeBlurView.m
+++ b/RealTimeBlur/Classes/DRNRealTimeBlurView.m
@@ -64,28 +64,36 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        
-        // Initialization code
-        self.tintLayer = [[CALayer alloc] init];
-        self.tintLayer.frame = self.bounds;
-        self.tintLayer.opacity = kDNRRealTimeBlurTintColorAlpha;
-        
-        //default tint
-        //TODO: Use tintColor on iOS 7
-        self.tint = [UIColor clearColor];
-        
-        [self.layer addSublayer:self.tintLayer];
-        
-        self.clipsToBounds = YES;
-        self.layer.cornerRadius = kDRNRealTimeBlurViewDefaultCornerRadius;
+        [self setup];
     }
     return self;
+}
+
+- (void)awakeFromNib {
+    [self setup];
+}
+
+- (void)setup {
+    // Initialization code
+    self.tintLayer = [[CALayer alloc] init];
+    self.tintLayer.frame = self.bounds;
+    self.tintLayer.opacity = kDNRRealTimeBlurTintColorAlpha;
+    
+    //default tint
+    //TODO: Use tintColor on iOS 7
+    self.tint = [UIColor clearColor];
+    
+    [self.layer addSublayer:self.tintLayer];
+    
+    self.clipsToBounds = YES;
+    self.layer.cornerRadius = kDRNRealTimeBlurViewDefaultCornerRadius;
 }
 
 - (void)dealloc
 {
     [[DRNRealTimeBlurViewManager sharedManager] deregisterView:self];
 }
+
 
 #pragma mark - Properties
 


### PR DESCRIPTION
Interface Builder doesn't call initWithFrame on IBOutlets. This change calls the initWithFrame code from awakeFromNib as well to rectify this problem.
