### PR TITLE
Fixing CGContextTranslateCTM: invalid context 0x0

### DIFF
--- a/RealTimeBlur/Classes/DRNRealTimeBlurView.m
+++ b/RealTimeBlur/Classes/DRNRealTimeBlurView.m
@@ -201,7 +201,8 @@
     [self toggleBlurViewsInView:superview hidden:YES alpha:alpha];
     
     //Render the layer in the image context
-    //Render the layer in the image context
+    if (visibleRect.size.width == 0 || visibleRect.size.height == 0) return;
+    
     UIGraphicsBeginImageContextWithOptions(visibleRect.size, NO, 1.0);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextTranslateCTM(context, -visibleRect.origin.x, -visibleRect.origin.y);

--- a/RealTimeBlur/Classes/DRNRealTimeBlurView.m
+++ b/RealTimeBlur/Classes/DRNRealTimeBlurView.m
@@ -201,7 +201,7 @@
     [self toggleBlurViewsInView:superview hidden:YES alpha:alpha];
     
     //Render the layer in the image context
-    if (visibleRect.size.width == 0 || visibleRect.size.height == 0) return;
+    if (CGRectIsEmpty(visibleRect)) return;
     
     UIGraphicsBeginImageContextWithOptions(visibleRect.size, NO, 1.0);
     CGContextRef context = UIGraphicsGetCurrentContext();


### PR DESCRIPTION
This errors happens when the `visibleArea` width or height are zero.
